### PR TITLE
Fix block purge command database query error

### DIFF
--- a/co.thor
+++ b/co.thor
@@ -173,6 +173,6 @@ class Co < Thor
       timestamp: @last_block.time,
       human_time: Time.at(@last_block.time)
     }
-    puts I18n.t(:resume_notice_message, params)
+    puts I18n.t(:resume_notice_message, **params)
   end
 end


### PR DESCRIPTION
Ruby 3.x requires explicit keyword argument splatting when passing a hash to a method that expects keyword arguments. Changed from `I18n.t(:key, params)` to `I18n.t(:key, **params)` to fix the ArgumentError "wrong number of arguments (given 2, expected 0..1)".